### PR TITLE
Adding Options + 2.1 HttpClient

### DIFF
--- a/AspNetMvcWebpack/AssetHelpers/AssetService.cs
+++ b/AspNetMvcWebpack/AssetHelpers/AssetService.cs
@@ -56,7 +56,7 @@ namespace AspNetMvcWebpack.AssetHelpers
                     throw new ArgumentException($"Unknown type {type}", nameof(type));
             }
 
-            asset = await GetFromManifestAsýnc(asset);
+            asset = await GetFromManifestAsync(asset);
 
             return asset != null
                 ? new HtmlString(GetTag(asset, type, load))
@@ -92,7 +92,7 @@ namespace AspNetMvcWebpack.AssetHelpers
             }
         }
 
-        private async Task<string> GetFromManifestAsýnc(string file)
+        private async Task<string> GetFromManifestAsync(string file)
         {
             JObject manifest;
 

--- a/AspNetMvcWebpack/AssetHelpers/AssetService.cs
+++ b/AspNetMvcWebpack/AssetHelpers/AssetService.cs
@@ -55,7 +55,7 @@ namespace AspNetMvcWebpack.AssetHelpers
                     asset += ".js";
                     break;
                 default:
-                    throw new ArgumentNullException(nameof(type));
+                    throw new ArgumentException($"Unknown type {type}", nameof(type));
             }
 
             asset = await GetFromManifestAsýnc(asset);

--- a/AspNetMvcWebpack/AssetHelpers/AssetService.cs
+++ b/AspNetMvcWebpack/AssetHelpers/AssetService.cs
@@ -11,9 +11,6 @@ namespace AspNetMvcWebpack.AssetHelpers
 {
     public class AssetService : IAssetService
     {
-        private const string PublicPath = "/dist/";
-        private const string ManifestFile = "manifest.json";
-
         private readonly HttpClient _httpClient;
 
         private readonly bool _developmentMode;
@@ -24,15 +21,20 @@ namespace AspNetMvcWebpack.AssetHelpers
 
         public AssetService(IHostingEnvironment hostingEnvironment, IOptions<WebpackOptions> options, HttpClient httpClient)
         {
+            if (options.Value == null)
+                throw new ArgumentNullException(nameof(options), "Webpack option cannot be null");
+
+            WebpackOptions webpack = options.Value;
+
             _developmentMode = hostingEnvironment.IsDevelopment();
 
             _manifestPath = _developmentMode
-                ? options.Value.DevServer + PublicPath + ManifestFile
-                : hostingEnvironment.WebRootPath + PublicPath + ManifestFile;
+                ? webpack.DevServer + webpack.AssetsPublicPath + webpack.ManifestFile
+                : hostingEnvironment.WebRootPath + webpack.AssetsPublicPath + webpack.ManifestFile;
 
             _assetPath = _developmentMode
-                ? options.Value.DevServer + PublicPath
-                : PublicPath;
+                ? webpack.DevServer + webpack.AssetsPublicPath
+                : webpack.AssetsPublicPath;
 
             if (_developmentMode) _httpClient = httpClient;
             else httpClient.Dispose();

--- a/AspNetMvcWebpack/AssetHelpers/AssetService.cs
+++ b/AspNetMvcWebpack/AssetHelpers/AssetService.cs
@@ -88,7 +88,7 @@ namespace AspNetMvcWebpack.AssetHelpers
                 case FileType.Js:
                     return $"<script src=\"{path}\" {loadType}></script>";
                 default:
-                    throw new ArgumentNullException(nameof(type));
+                    throw new ArgumentException($"Unknown type {type}", nameof(type));
             }
         }
 

--- a/AspNetMvcWebpack/AssetHelpers/AssetsHttpClient.cs
+++ b/AspNetMvcWebpack/AssetHelpers/AssetsHttpClient.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AspNetMvcWebpack.AssetHelpers
+{
+    /// <summary>
+    /// HttpClient to deal with webpack dev server
+    /// </summary>
+    public sealed class AssetsHttpClient : IAssetsHttpClient
+    {
+        /// <summary>
+        /// Dotnet internal http client
+        /// </summary>
+        private readonly HttpClient _httpClient;
+
+        /// <summary>
+        /// Webpack options
+        /// </summary>
+        private readonly WebpackOptions _options;
+
+        /// <summary>
+        /// Our logger
+        /// </summary>
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:AspNetMvcWebpack.AssetHelpers.AssetsHttpClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">Dotnet internal http client</param>
+        /// <param name="options">Webpack options</param>
+        /// <param name="logger">Our logger</param>
+        public AssetsHttpClient(HttpClient httpClient, IOptions<WebpackOptions> options, ILogger<AssetsHttpClient> logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+            _options = options.Value;
+        }
+
+        /// <summary>
+        /// Gets the content of the manifest file on the webpack dev server.
+        /// </summary>
+        /// <returns>The manifest content as json string.</returns>
+        public async Task<string> GetManifestContent()
+        {
+            _logger.LogInformation("Getting manifest content on dev server");
+
+            try
+            {
+                string result = await _httpClient.GetStringAsync($"/{_options.AssetsPublicPath.Trim('/')}/{_options.ManifestFile.TrimStart('/')}");
+
+                _logger.LogInformation("Retreived manifest content on dev server");
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Cannot retreive manifest file content on dev server");
+                throw ex;
+            }
+        }
+    }
+}

--- a/AspNetMvcWebpack/AssetHelpers/IAssetsHttpClient.cs
+++ b/AspNetMvcWebpack/AssetHelpers/IAssetsHttpClient.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace AspNetMvcWebpack.AssetHelpers
+{
+    /// <summary>
+    /// HttpClient to deal with webpack dev server
+    /// </summary>
+    public interface IAssetsHttpClient
+    {
+        /// <summary>
+        /// Gets the content of the manifest file on the webpack dev server.
+        /// </summary>
+        /// <returns>The manifest content as json string.</returns>
+        Task<string> GetManifestContent();
+    }
+}

--- a/AspNetMvcWebpack/AssetHelpers/WebpackOptions.cs
+++ b/AspNetMvcWebpack/AssetHelpers/WebpackOptions.cs
@@ -3,5 +3,9 @@ namespace AspNetMvcWebpack.AssetHelpers
     public class WebpackOptions
     {
         public string DevServer { get; set; }
+
+        public string ManifestFile { get; set; }
+
+        public string AssetsPublicPath { get; set; }
     }
 }

--- a/AspNetMvcWebpack/Startup.cs
+++ b/AspNetMvcWebpack/Startup.cs
@@ -13,12 +13,15 @@ namespace AspNetMvcWebpack
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
+        public Startup(IConfiguration configuration, IHostingEnvironment env)
         {
             Configuration = configuration;
+            Env = env;
         }
 
         public IConfiguration Configuration { get; }
+
+        public IHostingEnvironment Env { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -36,14 +39,21 @@ namespace AspNetMvcWebpack
                 throw new ApplicationException();
             
             services.Configure<WebpackOptions>(Configuration.GetSection("Webpack"));
-            services.AddTransient<HttpClient>();
+
+            if (Env.IsDevelopment())
+            {
+                services.AddHttpClient<IAssetsHttpClient, AssetsHttpClient>(client => {
+                    client.BaseAddress = new Uri(Configuration["Webpack:DevServer"].Trim('/'));
+                });
+            }
+
             services.AddSingleton<IAssetService, AssetService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app)
         {
-            if (env.IsDevelopment())
+            if (Env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }

--- a/AspNetMvcWebpack/Startup.cs
+++ b/AspNetMvcWebpack/Startup.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Net.Http;
 using AspNetMvcWebpack.AssetHelpers;
 using Microsoft.AspNetCore.Builder;
@@ -30,6 +32,9 @@ namespace AspNetMvcWebpack
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
+            if (!Configuration.GetChildren().Any(x => x.Key == "Webpack"))
+                throw new ApplicationException();
+            
             services.Configure<WebpackOptions>(Configuration.GetSection("Webpack"));
             services.AddTransient<HttpClient>();
             services.AddSingleton<IAssetService, AssetService>();

--- a/AspNetMvcWebpack/appsettings.Development.json
+++ b/AspNetMvcWebpack/appsettings.Development.json
@@ -1,6 +1,8 @@
 {
   "Webpack": {
-    "DevServer": "http://localhost:9000"
+    "DevServer": "http://localhost:9000",
+    "ManifestFile": "manifest.json",
+    "AssetsPublicPath": "/dist/"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Hello !

Here are some suggestions that I made in my PR :
- A more detailed WebpackOptions class to have a more modular config (in the case when someone doesn't want a /dist/ folder or name it's manifest differently)
- A dedicated HttpClient for the AssetsService, with no need to dispose when we are not in Development mode, and taking benefit from the HttpClient Factory system from the 2.1.

Don't hesitate to DM me or to add a reply if you want to discuss on some points in this PR :)